### PR TITLE
fix: unable to deduce from Configurable::Property into fmt::format

### DIFF
--- a/calorimetry/src/ClusterRecoCoG.cpp
+++ b/calorimetry/src/ClusterRecoCoG.cpp
@@ -46,7 +46,7 @@ void ClusterRecoCoG::init() {
     std::vector<std::string> keys;
     std::transform(weightMethods.begin(), weightMethods.end(), std::back_inserter(keys),
                    [](const auto& keyvalue) { return keyvalue.first; });
-    raise(fmt::format("Cannot find energy weighting method {}, choose one from {}", m_energyWeight,
+    raise(fmt::format("Cannot find energy weighting method {}, choose one from {}", ew,
                       keys));
   }
   m_weightFunc = weightMethods.at(ew);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This works around the following compilation error with fmt-10.1.1 and c++20. Only minor attempts were made at figuring out a real solution...
```
     59    /home/wdconinc/git/algorithms/calorimetry/src/ClusterRecoCoG.cpp:49:22:   required from here
  >> 60    /opt/software/linux-ubuntu23.04-skylake/gcc-12.3.0/fmt-10.1.1-ugstqub3fxqaeteorcf6xcqy2ieha55k/include/fmt/core.h:1308:28: error: no matching function for call to 'fmt::v10::formatter<algorithms::Configurable::Property<std::
           __cxx11::basic_string<char> >, char, void>::format(qualified_type&, fmt::v10::basic_format_context<fmt::v10::appender, char>&)'
     61     1308 |     ctx.advance_to(f.format(*static_cast<qualified_type*>(arg), ctx));
     62          |                    ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     63    /opt/software/linux-ubuntu23.04-skylake/gcc-12.3.0/fmt-10.1.1-ugstqub3fxqaeteorcf6xcqy2ieha55k/include/fmt/core.h:2712:22: note: candidate: 'template<class FormatContext> constexpr decltype (ctx.out()) fmt::v10::formatter<T,
            Char, typename std::enable_if<(fmt::v10::detail::type_constant<T, Char>::value != fmt::v10::detail::type::custom_type), void>::type>::format(const T&, FormatContext&) const [with T = fmt::v10::basic_string_view<char>; Char 
           = char]'
     64     2712 |   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
     65          |                      ^~~~~~
     66    /opt/software/linux-ubuntu23.04-skylake/gcc-12.3.0/fmt-10.1.1-ugstqub3fxqaeteorcf6xcqy2ieha55k/include/fmt/core.h:2712:22: note:   template argument deduction/substitution failed:
     67    /opt/software/linux-ubuntu23.04-skylake/gcc-12.3.0/fmt-10.1.1-ugstqub3fxqaeteorcf6xcqy2ieha55k/include/fmt/core.h:1308:28: note:   cannot convert '*(qualified_type*)arg' (type 'qualified_type' {aka 'algorithms::Configurable:
           :Property<std::__cxx11::basic_string<char> >'}) to type 'const fmt::v10::basic_string_view<char>&'
     68     1308 |     ctx.advance_to(f.format(*static_cast<qualified_type*>(arg), ctx));
     69          |                    ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  >> 70    make[2]: *** [calorimetry/CMakeFiles/algocalorimetry.dir/build.make:79: calorimetry/CMakeFiles/algocalorimetry.dir/src/ClusterRecoCoG.cpp.o] Error 1
     71    make[2]: Leaving directory '/home/wdconinc/git/algorithms/spack-build-5eif5fh'
  >> 72    make[1]: *** [CMakeFiles/Makefile2:163: calorimetry/CMakeFiles/algocalorimetry.dir/all] Error 2
     73    make[1]: Leaving directory '/home/wdconinc/git/algorithms/spack-build-5eif5fh'
  >> 74    make: *** [Makefile:139: all] Error 2
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.