### PR TITLE
fix: use edm4hep/utils/vector_utils instead of broken edm4eic version...

### DIFF
--- a/acts/include/algorithms/acts/ParticlesFromTrackFit.h
+++ b/acts/include/algorithms/acts/ParticlesFromTrackFit.h
@@ -31,7 +31,7 @@
 
 #include "Acts/Utilities/Helpers.hpp"
 
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include <cmath>
 
@@ -173,7 +173,7 @@ namespace Jug::Reco {
 
             auto rec_part = rec_parts->create();
             rec_part.setMomentum(
-              edm4eic::sphericalToVector(
+              edm4hep::utils::sphericalToVector(
                 1.0 / std::abs(params[Acts::eBoundQOverP]),
                 params[Acts::eBoundTheta],
                 params[Acts::eBoundPhi])

--- a/acts/include/algorithms/acts/TrackParamClusterInit.h
+++ b/acts/include/algorithms/acts/TrackParamClusterInit.h
@@ -18,7 +18,7 @@
 
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
@@ -84,14 +84,14 @@ public:
       if (p < 0.1 * GeV) {
         continue;
       }
-      double len    = edm4eic::magnitude(c.getPosition());
+      double len    = edm4hep::utils::magnitude(c.getPosition());
       auto momentum = c.getPosition() * p / len;
 
       Acts::BoundVector params;
       params(Acts::eBoundLoc0)   = 0.0 * mm;
       params(Acts::eBoundLoc1)   = 0.0 * mm;
-      params(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-      params(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+      params(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+      params(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
       params(Acts::eBoundQOverP) = 1 / p;
       params(Acts::eBoundTime)   = 0 * ns;
 
@@ -107,8 +107,8 @@ public:
       Acts::BoundVector params2;
       params2(Acts::eBoundLoc0)   = 0.0 * mm;
       params2(Acts::eBoundLoc1)   = 0.0 * mm;
-      params2(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-      params2(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+      params2(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+      params2(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
       params2(Acts::eBoundQOverP) = -1 / p;
       params2(Acts::eBoundTime)   = 0 * ns;
       init_trk_params->push_back({pSurface, params2, -1});

--- a/acts/include/algorithms/acts/TrackParamImagingClusterInit.h
+++ b/acts/include/algorithms/acts/TrackParamImagingClusterInit.h
@@ -18,7 +18,7 @@
 
 #include "edm4eic/TrackerHitCollection.h"
 #include "edm4eic/ClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
@@ -86,8 +86,8 @@ namespace Jug::Reco {
         if( p < 0.1*GeV) {
           continue;
         }
-        const double theta = edm4eic::anglePolar(c.getPosition());
-        const double phi = edm4eic::angleAzimuthal(c.getPosition());
+        const double theta = edm4hep::utils::anglePolar(c.getPosition());
+        const double phi = edm4hep::utils::angleAzimuthal(c.getPosition());
 
         Acts::BoundVector  params;
         params(Acts::eBoundLoc0)   = 0.0 * mm ;

--- a/acts/include/algorithms/acts/TrackParamVertexClusterInit.h
+++ b/acts/include/algorithms/acts/TrackParamVertexClusterInit.h
@@ -21,7 +21,7 @@
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -101,8 +101,8 @@ public:
         Acts::BoundVector params;
         params(Acts::eBoundLoc0)   = 0.0 * mm;
         params(Acts::eBoundLoc1)   = 0.0 * mm;
-        params(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-        params(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+        params(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+        params(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
         params(Acts::eBoundQOverP) = 1 / p_cluster;
         params(Acts::eBoundTime)   = 0 * ns;
 
@@ -114,8 +114,8 @@ public:
         Acts::BoundVector params2;
         params2(Acts::eBoundLoc0)   = 0.0 * mm;
         params2(Acts::eBoundLoc1)   = 0.0 * mm;
-        params2(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-        params2(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+        params2(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+        params2(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
         params2(Acts::eBoundQOverP) = -1 / p_cluster;
         params2(Acts::eBoundTime)   = 0 * ns;
         init_trk_params->push_back({pSurface, params2, -1});

--- a/acts/include/algorithms/acts/TrackProjector.h
+++ b/acts/include/algorithms/acts/TrackProjector.h
@@ -38,7 +38,7 @@
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include <cmath>
 
@@ -154,7 +154,7 @@ namespace Jug::Reco {
             static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1))
           };
           const decltype(edm4eic::TrackPoint::positionError) positionError{0, 0, 0};
-          const decltype(edm4eic::TrackPoint::momentum) momentum = edm4eic::sphericalToVector(
+          const decltype(edm4eic::TrackPoint::momentum) momentum = edm4hep::utils::sphericalToVector(
             static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP])),
             static_cast<float>(parameter[Acts::eBoundTheta]),
             static_cast<float>(parameter[Acts::eBoundPhi])

--- a/acts/src/ParticlesFromTrackFit.cpp
+++ b/acts/src/ParticlesFromTrackFit.cpp
@@ -31,7 +31,7 @@
 
 #include "Acts/Utilities/Helpers.hpp"
 
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include <cmath>
 
@@ -173,7 +173,7 @@ namespace Jug::Reco {
 
             auto rec_part = rec_parts->create();
             rec_part.setMomentum(
-              edm4eic::sphericalToVector(
+              edm4hep::utils::sphericalToVector(
                 1.0 / std::abs(params[Acts::eBoundQOverP]),
                 params[Acts::eBoundTheta],
                 params[Acts::eBoundPhi])

--- a/acts/src/TrackParamClusterInit.cpp
+++ b/acts/src/TrackParamClusterInit.cpp
@@ -18,7 +18,7 @@
 
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
@@ -84,14 +84,14 @@ public:
       if (p < 0.1 * GeV) {
         continue;
       }
-      double len    = edm4eic::magnitude(c.getPosition());
+      double len    = edm4hep::utils::magnitude(c.getPosition());
       auto momentum = c.getPosition() * p / len;
 
       Acts::BoundVector params;
       params(Acts::eBoundLoc0)   = 0.0 * mm;
       params(Acts::eBoundLoc1)   = 0.0 * mm;
-      params(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-      params(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+      params(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+      params(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
       params(Acts::eBoundQOverP) = 1 / p;
       params(Acts::eBoundTime)   = 0 * ns;
 
@@ -107,8 +107,8 @@ public:
       Acts::BoundVector params2;
       params2(Acts::eBoundLoc0)   = 0.0 * mm;
       params2(Acts::eBoundLoc1)   = 0.0 * mm;
-      params2(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-      params2(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+      params2(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+      params2(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
       params2(Acts::eBoundQOverP) = -1 / p;
       params2(Acts::eBoundTime)   = 0 * ns;
       init_trk_params->push_back({pSurface, params2, -1});

--- a/acts/src/TrackParamImagingClusterInit.cpp
+++ b/acts/src/TrackParamImagingClusterInit.cpp
@@ -18,7 +18,7 @@
 
 #include "edm4eic/TrackerHitCollection.h"
 #include "edm4eic/ClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
@@ -86,8 +86,8 @@ namespace Jug::Reco {
         if( p < 0.1*GeV) {
           continue;
         }
-        const double theta = edm4eic::anglePolar(c.getPosition());
-        const double phi = edm4eic::angleAzimuthal(c.getPosition());
+        const double theta = edm4hep::utils::anglePolar(c.getPosition());
+        const double phi = edm4hep::utils::angleAzimuthal(c.getPosition());
 
         Acts::BoundVector  params;
         params(Acts::eBoundLoc0)   = 0.0 * mm ;

--- a/acts/src/TrackParamVertexClusterInit.cpp
+++ b/acts/src/TrackParamVertexClusterInit.cpp
@@ -21,7 +21,7 @@
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -101,8 +101,8 @@ public:
         Acts::BoundVector params;
         params(Acts::eBoundLoc0)   = 0.0 * mm;
         params(Acts::eBoundLoc1)   = 0.0 * mm;
-        params(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-        params(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+        params(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+        params(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
         params(Acts::eBoundQOverP) = 1 / p_cluster;
         params(Acts::eBoundTime)   = 0 * ns;
 
@@ -114,8 +114,8 @@ public:
         Acts::BoundVector params2;
         params2(Acts::eBoundLoc0)   = 0.0 * mm;
         params2(Acts::eBoundLoc1)   = 0.0 * mm;
-        params2(Acts::eBoundPhi)    = edm4eic::angleAzimuthal(momentum);
-        params2(Acts::eBoundTheta)  = edm4eic::anglePolar(momentum);
+        params2(Acts::eBoundPhi)    = edm4hep::utils::angleAzimuthal(momentum);
+        params2(Acts::eBoundTheta)  = edm4hep::utils::anglePolar(momentum);
         params2(Acts::eBoundQOverP) = -1 / p_cluster;
         params2(Acts::eBoundTime)   = 0 * ns;
         init_trk_params->push_back({pSurface, params2, -1});

--- a/acts/src/TrackProjector.cpp
+++ b/acts/src/TrackProjector.cpp
@@ -37,7 +37,7 @@
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 #include <cmath>
 
@@ -153,7 +153,7 @@ namespace Jug::Reco {
             static_cast<float>(covariance(Acts::eBoundLoc0, Acts::eBoundLoc1))
           };
           const decltype(edm4eic::TrackPoint::positionError) positionError{0, 0, 0};
-          const decltype(edm4eic::TrackPoint::momentum) momentum = edm4eic::sphericalToVector(
+          const decltype(edm4eic::TrackPoint::momentum) momentum = edm4hep::utils::sphericalToVector(
             static_cast<float>(1.0 / std::abs(parameter[Acts::eBoundQOverP])),
             static_cast<float>(parameter[Acts::eBoundTheta]),
             static_cast<float>(parameter[Acts::eBoundPhi])

--- a/calorimetry/include/algorithms/calorimetry/todo/CalorimeterHitsEtaPhiProjector.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/CalorimeterHitsEtaPhiProjector.h
@@ -33,7 +33,7 @@
 
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 using Point3D = ROOT::Math::XYZPoint;
@@ -97,8 +97,8 @@ public:
 
     for (const auto h : *m_inputHitCollection.get()) {
       auto bins =
-          std::make_pair(static_cast<int64_t>(pos2bin(edm4eic::eta(h.getPosition()), gridSizes[0], 0.)),
-                         static_cast<int64_t>(pos2bin(edm4eic::angleAzimuthal(h.getPosition()), gridSizes[1], 0.)));
+          std::make_pair(static_cast<int64_t>(pos2bin(edm4hep::utils::eta(h.getPosition()), gridSizes[0], 0.)),
+                         static_cast<int64_t>(pos2bin(edm4hep::utils::angleAzimuthal(h.getPosition()), gridSizes[1], 0.)));
       merged_hits[bins].push_back(h);
     }
 
@@ -108,10 +108,10 @@ public:
       hit.setCellID(ref.getCellID());
       // TODO, we can do timing cut to reject noises
       hit.setTime(ref.getTime());
-      double r   = edm4eic::magnitude(ref.getPosition());
+      double r   = edm4hep::utils::magnitude(ref.getPosition());
       double eta = bin2pos(bins.first, gridSizes[0], 0.);
       double phi = bin2pos(bins.second, gridSizes[1], 1.);
-      hit.setPosition(edm4eic::sphericalToVector(r, edm4eic::etaToAngle(eta), phi));
+      hit.setPosition(edm4hep::utils::sphericalToVector(r, edm4hep::utils::etaToAngle(eta), phi));
       hit.setDimension({static_cast<float>(gridSizes[0]), static_cast<float>(gridSizes[1]), 0.});
       // merge energy
       hit.setEnergy(0.);

--- a/calorimetry/include/algorithms/calorimetry/todo/CalorimeterIslandCluster.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/CalorimeterIslandCluster.h
@@ -36,7 +36,7 @@
 #include "edm4eic/CalorimeterHitCollection.h"
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 #include "edm4hep/Vector3f.h"
 #include "edm4hep/Vector2f.h"
 
@@ -89,10 +89,10 @@ static Vector2f globalDistRPhi(const CaloHit& h1, const CaloHit& h2) {
   using vector_type = decltype(Vector2f::a);
   return {
     static_cast<vector_type>(
-      edm4eic::magnitude(h1.getPosition()) - edm4eic::magnitude(h2.getPosition())
+      edm4hep::utils::magnitude(h1.getPosition()) - edm4hep::utils::magnitude(h2.getPosition())
     ),
     static_cast<vector_type>(
-      edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())
+      edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())
     )
   };
 }
@@ -101,10 +101,10 @@ static Vector2f globalDistEtaPhi(const CaloHit& h1,
   using vector_type = decltype(Vector2f::a);
   return {
     static_cast<vector_type>(
-      edm4eic::eta(h1.getPosition()) - edm4eic::eta(h2.getPosition())
+      edm4hep::utils::eta(h1.getPosition()) - edm4hep::utils::eta(h2.getPosition())
     ),
     static_cast<vector_type>(
-      edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())
+      edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())
     )
   };
 }
@@ -273,7 +273,7 @@ private:
       // different sector, local coordinates do not work, using global coordinates
     } else {
       // sector may have rotation (barrel), so z is included
-      return (edm4eic::magnitude(h1.getPosition() - h2.getPosition()) <= sectorDist);
+      return (edm4hep::utils::magnitude(h1.getPosition() - h2.getPosition()) <= sectorDist);
     }
   }
 
@@ -392,7 +392,7 @@ private:
       for (const auto& chit : maxima) {
         double dist_ref = chit.getDimension().x;
         double energy   = chit.getEnergy();
-        double dist     = edm4eic::magnitude(hitsDist(chit, hit));
+        double dist     = edm4hep::utils::magnitude(hitsDist(chit, hit));
         weights[j]      = std::exp(-dist / dist_ref) * energy;
         j += 1;
       }

--- a/calorimetry/include/algorithms/calorimetry/todo/EnergyPositionClusterMerger.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/EnergyPositionClusterMerger.h
@@ -16,7 +16,7 @@
 
 // Event Model related classes
 #include "edm4eic/ClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -83,7 +83,7 @@ public:
         const auto& ec = e_clus[ie];
         // 1. stop if not within tolerance
         //    (make sure to handle rollover of phi properly)
-        double dphi = edm4eic::angleAzimuthal(pc.getPosition()) - edm4eic::angleAzimuthal(ec.getPosition());
+        double dphi = edm4hep::utils::angleAzimuthal(pc.getPosition()) - edm4hep::utils::angleAzimuthal(ec.getPosition());
         if (std::abs(dphi) > M_PI) {
           dphi = std::abs(dphi) - M_PI;
         }
@@ -120,13 +120,13 @@ public:
         if (msgLevel(MSG::DEBUG)) {
           debug() << fmt::format("Matched position cluster {} with energy cluster {}\n", pc.id(), ec.id()) << endmsg;
           debug() << fmt::format("  - Position cluster: (E: {}, phi: {}, z: {})", pc.getEnergy(),
-                                 edm4eic::angleAzimuthal(pc.getPosition()), pc.getPosition().z)
+                                 edm4hep::utils::angleAzimuthal(pc.getPosition()), pc.getPosition().z)
                   << endmsg;
           debug() << fmt::format("  - Energy cluster: (E: {}, phi: {}, z: {})", ec.getEnergy(),
-                                 edm4eic::angleAzimuthal(ec.getPosition()), ec.getPosition().z)
+                                 edm4hep::utils::angleAzimuthal(ec.getPosition()), ec.getPosition().z)
                   << endmsg;
           debug() << fmt::format("  ---> Merged cluster: (E: {}, phi: {}, z: {})", new_clus.getEnergy(),
-                                 edm4eic::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z)
+                                 edm4hep::utils::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z)
                   << endmsg;
         }
       }

--- a/calorimetry/include/algorithms/calorimetry/todo/ImagingClusterReco.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/ImagingClusterReco.h
@@ -35,7 +35,7 @@
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 using namespace Eigen;
@@ -251,7 +251,7 @@ private:
     // Calculate radius as the standard deviation of the hits versus the cluster center
     double radius = 0.;
     for (const auto& [hit, weight] : hits) {
-      radius += std::pow(edm4eic::magnitude(hit.getPosition() - layer.getPosition()), 2);
+      radius += std::pow(edm4hep::utils::magnitude(hit.getPosition() - layer.getPosition()), 2);
     }
     layer.addToShapeParameters(std::sqrt(radius / layer.getNhits()));
     // TODO Skewedness
@@ -282,9 +282,9 @@ private:
       const double energyWeight = hit.getEnergy() * weight;
       time += hit.getTime() * energyWeight;
       timeError += std::pow(hit.getTimeError() * energyWeight, 2);
-      meta += edm4eic::eta(hit.getPosition()) * energyWeight;
-      mphi += edm4eic::angleAzimuthal(hit.getPosition()) * energyWeight;
-      r = std::min(edm4eic::magnitude(hit.getPosition()), r);
+      meta += edm4hep::utils::eta(hit.getPosition()) * energyWeight;
+      mphi += edm4hep::utils::angleAzimuthal(hit.getPosition()) * energyWeight;
+      r = std::min(edm4hep::utils::magnitude(hit.getPosition()), r);
       cluster.addToHits(hit);
     }
     cluster.setEnergy(energy);
@@ -292,13 +292,13 @@ private:
     cluster.setTime(time / energy);
     cluster.setTimeError(std::sqrt(timeError) / energy);
     cluster.setNhits(hits.size());
-    cluster.setPosition(edm4eic::sphericalToVector(r, edm4eic::etaToAngle(meta / energy), mphi / energy));
+    cluster.setPosition(edm4hep::utils::sphericalToVector(r, edm4hep::utils::etaToAngle(meta / energy), mphi / energy));
 
     // shower radius estimate (eta-phi plane)
     double radius = 0.;
     for (const auto& hit : hits) {
-      radius += pow2(edm4eic::eta(hit.getPosition()) - edm4eic::eta(cluster.getPosition())) +
-                pow2(edm4eic::angleAzimuthal(hit.getPosition()) - edm4eic::angleAzimuthal(cluster.getPosition()));
+      radius += pow2(edm4hep::utils::eta(hit.getPosition()) - edm4hep::utils::eta(cluster.getPosition())) +
+                pow2(edm4hep::utils::angleAzimuthal(hit.getPosition()) - edm4hep::utils::angleAzimuthal(cluster.getPosition()));
     }
     cluster.addToShapeParameters(std::sqrt(radius / cluster.getNhits()));
     // Skewedness not calculated TODO

--- a/calorimetry/include/algorithms/calorimetry/todo/ImagingPixelDataCombiner.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/ImagingPixelDataCombiner.h
@@ -29,7 +29,7 @@
 
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 

--- a/calorimetry/include/algorithms/calorimetry/todo/ImagingPixelDataSorter.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/ImagingPixelDataSorter.h
@@ -27,7 +27,7 @@
 #include "JugBase/Utilities/Utils.hpp"
 
 // Event Model related classes
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 #include "edm4eic/CalorimeterHit.h"
 #include "edm4eic/CalorimeterHitCollection.h"
 

--- a/calorimetry/include/algorithms/calorimetry/todo/ImagingPixelMerger.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/ImagingPixelMerger.h
@@ -32,7 +32,7 @@
 
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 using namespace Gaudi::Units;
 
@@ -102,9 +102,9 @@ public:
       const auto& pos = h.getPosition();
 
       // cylindrical r
-      const float rc   = edm4eic::magnitudeTransverse(pos);
-      const double eta = edm4eic::eta(pos);
-      const double phi = edm4eic::angleAzimuthal(pos);
+      const float rc   = edm4hep::utils::magnitudeTransverse(pos);
+      const double eta = edm4hep::utils::eta(pos);
+      const double phi = edm4hep::utils::angleAzimuthal(pos);
 
       const auto grid = std::pair<int, int>{pos2grid(eta, m_etaSize), pos2grid(phi, m_phiSize)};
       auto it         = layer.find(grid);
@@ -132,10 +132,10 @@ public:
       for (const auto& [grid, data] : layer) {
         const double eta   = grid2pos(grid.first, m_etaSize);
         const double phi   = grid2pos(grid.second, m_phiSize);
-        const double theta = edm4eic::etaToAngle(eta);
+        const double theta = edm4hep::utils::etaToAngle(eta);
         const double z     = cotan(theta) * data.rc;
         const float r      = std::hypot(data.rc, z);
-        const auto pos     = edm4eic::sphericalToVector(r, theta, phi);
+        const auto pos     = edm4hep::utils::sphericalToVector(r, theta, phi);
         auto oh            = ohits.create();
         oh.setEnergy(data.energy);
         oh.setEnergyError(std::sqrt(data.energyError));

--- a/calorimetry/include/algorithms/calorimetry/todo/ImagingTopoCluster.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/ImagingTopoCluster.h
@@ -32,7 +32,7 @@
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -198,8 +198,8 @@ private:
       return (std::abs(h1.getLocal().x - h2.getLocal().x) <= localDistXY[0]) &&
              (std::abs(h1.getLocal().y - h2.getLocal().y) <= localDistXY[1]);
     } else if (ldiff <= m_neighbourLayersRange) {
-      return (std::abs(edm4eic::eta(h1.getPosition()) - edm4eic::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
-             (std::abs(edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())) <=
+      return (std::abs(edm4hep::utils::eta(h1.getPosition()) - edm4hep::utils::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
+             (std::abs(edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())) <=
               layerDistEtaPhi[1]);
     }
 

--- a/calorimetry/include/algorithms/calorimetry/todo/SimpleClustering.h
+++ b/calorimetry/include/algorithms/calorimetry/todo/SimpleClustering.h
@@ -24,7 +24,7 @@
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
 #include "edm4eic/RawCalorimeterHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -127,7 +127,7 @@ namespace Jug::Reco {
         std::vector<std::pair<uint32_t, edm4eic::CalorimeterHit>> cluster_hits;
 
         for (const auto& [idx, h] : the_hits) {
-          if (edm4eic::magnitude(h.getPosition() - ref_hit.getPosition()) < max_dist) {
+          if (edm4hep::utils::magnitude(h.getPosition() - ref_hit.getPosition()) < max_dist) {
             cluster_hits.emplace_back(idx, h);
           } else {
             remaining_hits.emplace_back(idx, h);

--- a/calorimetry/src/ClusterRecoCoG.cpp
+++ b/calorimetry/src/ClusterRecoCoG.cpp
@@ -18,7 +18,7 @@
 #include <fmt/ranges.h>
 
 // Event Model related classes
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace algorithms::calorimetry {
 namespace {
@@ -124,7 +124,7 @@ void ClusterRecoCoG::process(const ClusterRecoCoG::Input& input,
         debug() << "corresponding mc hit energy " << mchit->getEnergy() << " at index "
                 << mchit->getObjectID().index << endmsg;
         debug() << "from MCParticle index " << mcp.getObjectID().index << ", PDG " << mcp.getPDG()
-                << ", " << edm4eic::magnitude(mcp.getMomentum()) << endmsg;
+                << ", " << edm4hep::utils::magnitude(mcp.getMomentum()) << endmsg;
       }
 
       // set association
@@ -174,7 +174,7 @@ edm4eic::MutableCluster ClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster&
     totalE += energy;
     if (energy > maxE) {
     }
-    const float eta = edm4eic::eta(hit.getPosition());
+    const float eta = edm4hep::utils::eta(hit.getPosition());
     if (eta < minHitEta) {
       minHitEta = eta;
     }
@@ -206,14 +206,14 @@ edm4eic::MutableCluster ClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster&
 
   // Optionally constrain the cluster to the hit eta values
   if (m_enableEtaBounds) {
-    const bool overflow  = (edm4eic::eta(cl.getPosition()) > maxHitEta);
-    const bool underflow = (edm4eic::eta(cl.getPosition()) < minHitEta);
+    const bool overflow  = (edm4hep::utils::eta(cl.getPosition()) > maxHitEta);
+    const bool underflow = (edm4hep::utils::eta(cl.getPosition()) < minHitEta);
     if (overflow || underflow) {
       const double newEta   = overflow ? maxHitEta : minHitEta;
-      const double newTheta = edm4eic::etaToAngle(newEta);
-      const double newR     = edm4eic::magnitude(cl.getPosition());
-      const double newPhi   = edm4eic::angleAzimuthal(cl.getPosition());
-      cl.setPosition(edm4eic::sphericalToVector(newR, newTheta, newPhi));
+      const double newTheta = edm4hep::utils::etaToAngle(newEta);
+      const double newR     = edm4hep::utils::magnitude(cl.getPosition());
+      const double newPhi   = edm4hep::utils::angleAzimuthal(cl.getPosition());
+      cl.setPosition(edm4hep::utils::sphericalToVector(newR, newTheta, newPhi));
       if (aboveDebugThreshold()) {
         debug() << "Bound cluster position to contributing hits due to "
                 << (overflow ? "overflow" : "underflow") << endmsg;
@@ -225,8 +225,8 @@ edm4eic::MutableCluster ClusterRecoCoG::reconstruct(const edm4eic::ProtoCluster&
 
   // best estimate on the cluster direction is the cluster position
   // for simple 2D CoG clustering
-  cl.setIntrinsicTheta(edm4eic::anglePolar(cl.getPosition()));
-  cl.setIntrinsicPhi(edm4eic::angleAzimuthal(cl.getPosition()));
+  cl.setIntrinsicTheta(edm4hep::utils::anglePolar(cl.getPosition()));
+  cl.setIntrinsicPhi(edm4hep::utils::angleAzimuthal(cl.getPosition()));
   // TODO errors
 
   // Calculate radius

--- a/calorimetry/src/todo/CalorimeterHitsEtaPhiProjector.cpp
+++ b/calorimetry/src/todo/CalorimeterHitsEtaPhiProjector.cpp
@@ -33,7 +33,7 @@
 
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 using Point3D = ROOT::Math::XYZPoint;
@@ -97,8 +97,8 @@ public:
 
     for (const auto h : *m_inputHitCollection.get()) {
       auto bins =
-          std::make_pair(static_cast<int64_t>(pos2bin(edm4eic::eta(h.getPosition()), gridSizes[0], 0.)),
-                         static_cast<int64_t>(pos2bin(edm4eic::angleAzimuthal(h.getPosition()), gridSizes[1], 0.)));
+          std::make_pair(static_cast<int64_t>(pos2bin(edm4hep::utils::eta(h.getPosition()), gridSizes[0], 0.)),
+                         static_cast<int64_t>(pos2bin(edm4hep::utils::angleAzimuthal(h.getPosition()), gridSizes[1], 0.)));
       merged_hits[bins].push_back(h);
     }
 
@@ -108,10 +108,10 @@ public:
       hit.setCellID(ref.getCellID());
       // TODO, we can do timing cut to reject noises
       hit.setTime(ref.getTime());
-      double r   = edm4eic::magnitude(ref.getPosition());
+      double r   = edm4hep::utils::magnitude(ref.getPosition());
       double eta = bin2pos(bins.first, gridSizes[0], 0.);
       double phi = bin2pos(bins.second, gridSizes[1], 1.);
-      hit.setPosition(edm4eic::sphericalToVector(r, edm4eic::etaToAngle(eta), phi));
+      hit.setPosition(edm4hep::utils::sphericalToVector(r, edm4hep::utils::etaToAngle(eta), phi));
       hit.setDimension({static_cast<float>(gridSizes[0]), static_cast<float>(gridSizes[1]), 0.});
       // merge energy
       hit.setEnergy(0.);

--- a/calorimetry/src/todo/CalorimeterIslandCluster.cpp
+++ b/calorimetry/src/todo/CalorimeterIslandCluster.cpp
@@ -37,7 +37,7 @@
 #include "edm4eic/CalorimeterHitCollection.h"
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 #include "edm4hep/Vector3f.h"
 #include "edm4hep/Vector2f.h"
 
@@ -94,10 +94,10 @@ static Vector2f globalDistRPhi(const CaloHit& h1, const CaloHit& h2) {
   using vector_type = decltype(Vector2f::a);
   return {
     static_cast<vector_type>(
-      edm4eic::magnitude(h1.getPosition()) - edm4eic::magnitude(h2.getPosition())
+      edm4hep::utils::magnitude(h1.getPosition()) - edm4hep::utils::magnitude(h2.getPosition())
     ),
     static_cast<vector_type>(
-      edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())
+      edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())
     )
   };
 }
@@ -106,10 +106,10 @@ static Vector2f globalDistEtaPhi(const CaloHit& h1,
   using vector_type = decltype(Vector2f::a);
   return {
     static_cast<vector_type>(
-      edm4eic::eta(h1.getPosition()) - edm4eic::eta(h2.getPosition())
+      edm4hep::utils::eta(h1.getPosition()) - edm4hep::utils::eta(h2.getPosition())
     ),
     static_cast<vector_type>(
-      edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())
+      edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())
     )
   };
 }
@@ -272,7 +272,7 @@ public:
               // different sector, local coordinates do not work, using global coordinates
             } else {
               // sector may have rotation (barrel), so z is included
-              return (edm4eic::magnitude(h1.getPosition() - h2.getPosition()) <= sectorDist);
+              return (edm4hep::utils::magnitude(h1.getPosition() - h2.getPosition()) <= sectorDist);
             }
           };
 
@@ -447,7 +447,7 @@ private:
       for (const auto& chit : maxima) {
         double dist_ref = chit.getDimension().x;
         double energy   = chit.getEnergy();
-        double dist     = edm4eic::magnitude(hitsDist(chit, hit));
+        double dist     = edm4hep::utils::magnitude(hitsDist(chit, hit));
         weights[j]      = std::exp(-dist / dist_ref) * energy;
         j += 1;
       }

--- a/calorimetry/src/todo/EnergyPositionClusterMerger.cpp
+++ b/calorimetry/src/todo/EnergyPositionClusterMerger.cpp
@@ -16,7 +16,7 @@
 
 // Event Model related classes
 #include "edm4eic/ClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -83,7 +83,7 @@ public:
         const auto& ec = e_clus[ie];
         // 1. stop if not within tolerance
         //    (make sure to handle rollover of phi properly)
-        double dphi = edm4eic::angleAzimuthal(pc.getPosition()) - edm4eic::angleAzimuthal(ec.getPosition());
+        double dphi = edm4hep::utils::angleAzimuthal(pc.getPosition()) - edm4hep::utils::angleAzimuthal(ec.getPosition());
         if (std::abs(dphi) > M_PI) {
           dphi = std::abs(dphi) - M_PI;
         }
@@ -120,13 +120,13 @@ public:
         if (msgLevel(MSG::DEBUG)) {
           debug() << fmt::format("Matched position cluster {} with energy cluster {}\n", pc.id(), ec.id()) << endmsg;
           debug() << fmt::format("  - Position cluster: (E: {}, phi: {}, z: {})", pc.getEnergy(),
-                                 edm4eic::angleAzimuthal(pc.getPosition()), pc.getPosition().z)
+                                 edm4hep::utils::angleAzimuthal(pc.getPosition()), pc.getPosition().z)
                   << endmsg;
           debug() << fmt::format("  - Energy cluster: (E: {}, phi: {}, z: {})", ec.getEnergy(),
-                                 edm4eic::angleAzimuthal(ec.getPosition()), ec.getPosition().z)
+                                 edm4hep::utils::angleAzimuthal(ec.getPosition()), ec.getPosition().z)
                   << endmsg;
           debug() << fmt::format("  ---> Merged cluster: (E: {}, phi: {}, z: {})", new_clus.getEnergy(),
-                                 edm4eic::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z)
+                                 edm4hep::utils::angleAzimuthal(new_clus.getPosition()), new_clus.getPosition().z)
                   << endmsg;
         }
       }

--- a/calorimetry/src/todo/ImagingClusterReco.cpp
+++ b/calorimetry/src/todo/ImagingClusterReco.cpp
@@ -35,7 +35,7 @@
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 using namespace Eigen;
@@ -251,7 +251,7 @@ private:
     // Calculate radius as the standard deviation of the hits versus the cluster center
     double radius = 0.;
     for (const auto& [hit, weight] : hits) {
-      radius += std::pow(edm4eic::magnitude(hit.getPosition() - layer.getPosition()), 2);
+      radius += std::pow(edm4hep::utils::magnitude(hit.getPosition() - layer.getPosition()), 2);
     }
     layer.addToShapeParameters(std::sqrt(radius / layer.getNhits()));
     // TODO Skewedness
@@ -282,9 +282,9 @@ private:
       const double energyWeight = hit.getEnergy() * weight;
       time += hit.getTime() * energyWeight;
       timeError += std::pow(hit.getTimeError() * energyWeight, 2);
-      meta += edm4eic::eta(hit.getPosition()) * energyWeight;
-      mphi += edm4eic::angleAzimuthal(hit.getPosition()) * energyWeight;
-      r = std::min(edm4eic::magnitude(hit.getPosition()), r);
+      meta += edm4hep::utils::eta(hit.getPosition()) * energyWeight;
+      mphi += edm4hep::utils::angleAzimuthal(hit.getPosition()) * energyWeight;
+      r = std::min(edm4hep::utils::magnitude(hit.getPosition()), r);
       cluster.addToHits(hit);
     }
     cluster.setEnergy(energy);
@@ -292,13 +292,13 @@ private:
     cluster.setTime(time / energy);
     cluster.setTimeError(std::sqrt(timeError) / energy);
     cluster.setNhits(hits.size());
-    cluster.setPosition(edm4eic::sphericalToVector(r, edm4eic::etaToAngle(meta / energy), mphi / energy));
+    cluster.setPosition(edm4hep::utils::sphericalToVector(r, edm4hep::utils::etaToAngle(meta / energy), mphi / energy));
 
     // shower radius estimate (eta-phi plane)
     double radius = 0.;
     for (const auto& hit : hits) {
-      radius += pow2(edm4eic::eta(hit.getPosition()) - edm4eic::eta(cluster.getPosition())) +
-                pow2(edm4eic::angleAzimuthal(hit.getPosition()) - edm4eic::angleAzimuthal(cluster.getPosition()));
+      radius += pow2(edm4hep::utils::eta(hit.getPosition()) - edm4hep::utils::eta(cluster.getPosition())) +
+                pow2(edm4hep::utils::angleAzimuthal(hit.getPosition()) - edm4hep::utils::angleAzimuthal(cluster.getPosition()));
     }
     cluster.addToShapeParameters(std::sqrt(radius / cluster.getNhits()));
     // Skewedness not calculated TODO

--- a/calorimetry/src/todo/ImagingPixelDataCombiner.cpp
+++ b/calorimetry/src/todo/ImagingPixelDataCombiner.cpp
@@ -29,7 +29,7 @@
 
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 

--- a/calorimetry/src/todo/ImagingPixelDataSorter.cpp
+++ b/calorimetry/src/todo/ImagingPixelDataSorter.cpp
@@ -27,7 +27,7 @@
 #include "JugBase/Utilities/Utils.hpp"
 
 // Event Model related classes
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 #include "edm4eic/CalorimeterHit.h"
 #include "edm4eic/CalorimeterHitCollection.h"
 

--- a/calorimetry/src/todo/ImagingPixelMerger.cpp
+++ b/calorimetry/src/todo/ImagingPixelMerger.cpp
@@ -32,7 +32,7 @@
 
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 using namespace Gaudi::Units;
 
@@ -102,9 +102,9 @@ public:
       const auto& pos = h.getPosition();
 
       // cylindrical r
-      const float rc   = edm4eic::magnitudeTransverse(pos);
-      const double eta = edm4eic::eta(pos);
-      const double phi = edm4eic::angleAzimuthal(pos);
+      const float rc   = edm4hep::utils::magnitudeTransverse(pos);
+      const double eta = edm4hep::utils::eta(pos);
+      const double phi = edm4hep::utils::angleAzimuthal(pos);
 
       const auto grid = std::pair<int, int>{pos2grid(eta, m_etaSize), pos2grid(phi, m_phiSize)};
       auto it         = layer.find(grid);
@@ -132,10 +132,10 @@ public:
       for (const auto& [grid, data] : layer) {
         const double eta   = grid2pos(grid.first, m_etaSize);
         const double phi   = grid2pos(grid.second, m_phiSize);
-        const double theta = edm4eic::etaToAngle(eta);
+        const double theta = edm4hep::utils::etaToAngle(eta);
         const double z     = cotan(theta) * data.rc;
         const float r      = std::hypot(data.rc, z);
-        const auto pos     = edm4eic::sphericalToVector(r, theta, phi);
+        const auto pos     = edm4hep::utils::sphericalToVector(r, theta, phi);
         auto oh            = ohits.create();
         oh.setEnergy(data.energy);
         oh.setEnergyError(std::sqrt(data.energyError));

--- a/calorimetry/src/todo/ImagingTopoCluster.cpp
+++ b/calorimetry/src/todo/ImagingTopoCluster.cpp
@@ -32,7 +32,7 @@
 // Event Model related classes
 #include "edm4eic/CalorimeterHitCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -198,8 +198,8 @@ private:
       return (std::abs(h1.getLocal().x - h2.getLocal().x) <= localDistXY[0]) &&
              (std::abs(h1.getLocal().y - h2.getLocal().y) <= localDistXY[1]);
     } else if (ldiff <= m_neighbourLayersRange) {
-      return (std::abs(edm4eic::eta(h1.getPosition()) - edm4eic::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
-             (std::abs(edm4eic::angleAzimuthal(h1.getPosition()) - edm4eic::angleAzimuthal(h2.getPosition())) <=
+      return (std::abs(edm4hep::utils::eta(h1.getPosition()) - edm4hep::utils::eta(h2.getPosition())) <= layerDistEtaPhi[0]) &&
+             (std::abs(edm4hep::utils::angleAzimuthal(h1.getPosition()) - edm4hep::utils::angleAzimuthal(h2.getPosition())) <=
               layerDistEtaPhi[1]);
     }
 

--- a/calorimetry/src/todo/SimpleClustering.cpp
+++ b/calorimetry/src/todo/SimpleClustering.cpp
@@ -24,7 +24,7 @@
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/ProtoClusterCollection.h"
 #include "edm4eic/RawCalorimeterHitCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 
@@ -127,7 +127,7 @@ namespace Jug::Reco {
         std::vector<std::pair<uint32_t, edm4eic::CalorimeterHit>> cluster_hits;
 
         for (const auto& [idx, h] : the_hits) {
-          if (edm4eic::magnitude(h.getPosition() - ref_hit.getPosition()) < max_dist) {
+          if (edm4hep::utils::magnitude(h.getPosition() - ref_hit.getPosition()) < max_dist) {
             cluster_hits.emplace_back(idx, h);
           } else {
             remaining_hits.emplace_back(idx, h);

--- a/far_forward/include/algorithms/far_forward/todo/FarForwardParticles.h
+++ b/far_forward/include/algorithms/far_forward/todo/FarForwardParticles.h
@@ -21,7 +21,7 @@
 // Event Model related classes
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 namespace Jug::Reco {
 
@@ -258,7 +258,7 @@ public:
       edm4eic::MutableReconstructedParticle rpTrack;
       rpTrack.setType(0);
       rpTrack.setMomentum({prec});
-      rpTrack.setEnergy(std::hypot(edm4eic::magnitude(rpTrack.getMomentum()), .938272));
+      rpTrack.setEnergy(std::hypot(edm4hep::utils::magnitude(rpTrack.getMomentum()), .938272));
       rpTrack.setReferencePoint({0, 0, 0});
       rpTrack.setCharge(1);
       rpTrack.setMass(.938272);

--- a/far_forward/include/algorithms/far_forward/todo/FarForwardParticlesOMD.h
+++ b/far_forward/include/algorithms/far_forward/todo/FarForwardParticlesOMD.h
@@ -16,7 +16,7 @@
 // Event Model related classes
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 namespace Jug::Reco {
 
@@ -167,7 +167,7 @@ public:
       edm4eic::MutableReconstructedParticle rpTrack;
       rpTrack.setType(0);
       rpTrack.setMomentum({prec});
-      rpTrack.setEnergy(std::hypot(edm4eic::magnitude(rpTrack.getMomentum()), .938272));
+      rpTrack.setEnergy(std::hypot(edm4hep::utils::magnitude(rpTrack.getMomentum()), .938272));
       rpTrack.setReferencePoint({0, 0, 0});
       rpTrack.setCharge(1);
       rpTrack.setMass(.938272);

--- a/far_forward/src/todo/FarForwardParticles.cpp
+++ b/far_forward/src/todo/FarForwardParticles.cpp
@@ -21,7 +21,7 @@
 // Event Model related classes
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 namespace Jug::Reco {
 
@@ -258,7 +258,7 @@ public:
       edm4eic::MutableReconstructedParticle rpTrack;
       rpTrack.setType(0);
       rpTrack.setMomentum({prec});
-      rpTrack.setEnergy(std::hypot(edm4eic::magnitude(rpTrack.getMomentum()), .938272));
+      rpTrack.setEnergy(std::hypot(edm4hep::utils::magnitude(rpTrack.getMomentum()), .938272));
       rpTrack.setReferencePoint({0, 0, 0});
       rpTrack.setCharge(1);
       rpTrack.setMass(.938272);

--- a/far_forward/src/todo/FarForwardParticlesOMD.cpp
+++ b/far_forward/src/todo/FarForwardParticlesOMD.cpp
@@ -16,7 +16,7 @@
 // Event Model related classes
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/TrackerHitCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 namespace Jug::Reco {
 
@@ -167,7 +167,7 @@ public:
       edm4eic::MutableReconstructedParticle rpTrack;
       rpTrack.setType(0);
       rpTrack.setMomentum({prec});
-      rpTrack.setEnergy(std::hypot(edm4eic::magnitude(rpTrack.getMomentum()), .938272));
+      rpTrack.setEnergy(std::hypot(edm4hep::utils::magnitude(rpTrack.getMomentum()), .938272));
       rpTrack.setReferencePoint({0, 0, 0});
       rpTrack.setCharge(1);
       rpTrack.setMass(.938272);

--- a/truth/include/algorithms/truth/todo/ClusterMerger.h
+++ b/truth/include/algorithms/truth/todo/ClusterMerger.h
@@ -17,7 +17,7 @@
 // Event Model related classes
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 

--- a/truth/include/algorithms/truth/todo/InclusiveKinematicsTruth.h
+++ b/truth/include/algorithms/truth/todo/InclusiveKinematicsTruth.h
@@ -22,7 +22,7 @@ using ROOT::Math::PxPyPzEVector;
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/InclusiveKinematicsCollection.h"
 
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace Jug::Fast {
 
@@ -89,7 +89,7 @@ public:
       return StatusCode::SUCCESS;
     }
     const auto ei_p = ei_coll[0].getMomentum();
-    const auto ei_p_mag = edm4eic::magnitude(ei_p);
+    const auto ei_p_mag = edm4hep::utils::magnitude(ei_p);
     const auto ei_mass = m_electron;
     const PxPyPzEVector ei(ei_p.x, ei_p.y, ei_p.z, std::hypot(ei_p_mag, ei_mass));
 
@@ -102,7 +102,7 @@ public:
       return StatusCode::SUCCESS;
     }
     const auto pi_p = pi_coll[0].getMomentum();
-    const auto pi_p_mag = edm4eic::magnitude(pi_p);
+    const auto pi_p_mag = edm4hep::utils::magnitude(pi_p);
     const auto pi_mass = pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron;
     const PxPyPzEVector pi(pi_p.x, pi_p.y, pi_p.z, std::hypot(pi_p_mag, pi_mass));
 
@@ -119,7 +119,7 @@ public:
       return StatusCode::SUCCESS;
     }
     const auto ef_p = ef_coll[0].getMomentum();
-    const auto ef_p_mag = edm4eic::magnitude(ef_p);
+    const auto ef_p_mag = edm4hep::utils::magnitude(ef_p);
     const auto ef_mass = m_electron;
     const PxPyPzEVector ef(ef_p.x, ef_p.y, ef_p.z, std::hypot(ef_p_mag, ef_mass));
 

--- a/truth/include/algorithms/truth/todo/MatchClusters.h
+++ b/truth/include/algorithms/truth/todo/MatchClusters.h
@@ -25,7 +25,7 @@
 #include "edm4eic/MCRecoParticleAssociationCollection.h"
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/TrackParametersCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace Jug::Fast {
 
@@ -271,7 +271,7 @@ private:
     const float energy = clus.getEnergy();
     const float p = energy < mass ? 0 : std::sqrt(energy * energy - mass * mass);
     const auto position = clus.getPosition();
-    const auto momentum = p * (position / edm4eic::magnitude(position));
+    const auto momentum = p * (position / edm4hep::utils::magnitude(position));
     // setup our particle
     edm4eic::MutableReconstructedParticle part;
     part.setMomentum(momentum);

--- a/truth/include/algorithms/truth/todo/SmearedFarForwardParticles.h
+++ b/truth/include/algorithms/truth/todo/SmearedFarForwardParticles.h
@@ -17,7 +17,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/MCRecoParticleAssociationCollection.h"
 #include "edm4eic/ReconstructedParticleCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace {
 enum DetectorTags { kTagB0 = 1, kTagRP = 2, kTagOMD = 3, kTagZDC = 4 };
@@ -160,8 +160,8 @@ private:
         continue;
       }
       // only 0-->4.5 mrad
-      const double mom_ion_theta = edm4eic::anglePolar(mom_ion);
-      const double mom_ion_phi   = edm4eic::angleAzimuthal(mom_ion);
+      const double mom_ion_theta = edm4hep::utils::anglePolar(mom_ion);
+      const double mom_ion_phi   = edm4hep::utils::angleAzimuthal(mom_ion);
       if (mom_ion_theta > 4.5 / 1000.) {
         continue;
       }
@@ -192,7 +192,7 @@ private:
       const double phis = phi + dphi;
       const double moms = sqrt(Es * Es - part.getMass() * part.getMass());
       // now cast back into float
-      const auto mom3s_ion = edm4eic::sphericalToVector(moms, ths, phis);
+      const auto mom3s_ion = edm4hep::utils::sphericalToVector(moms, ths, phis);
       const auto mom3s     = rotateIonToLabDirection(mom3s_ion);
       RecPart rec_part;
       rec_part.setType(kTagZDC);
@@ -220,8 +220,8 @@ private:
         debug()
             << fmt::format(
                    "Found ZDC particle: {}, Etrue: {}, Emeas: {}, ptrue: {}, pmeas: {}, theta_true: {}, theta_meas: {}",
-                   part.getPDG(), E, rec_part.getEnergy(), part_p_mag, edm4eic::magnitude(rec_part.getMomentum()), th,
-                   edm4eic::anglePolar(rec_part.getMomentum()))
+                   part.getPDG(), E, rec_part.getEnergy(), part_p_mag, edm4hep::utils::magnitude(rec_part.getMomentum()), th,
+                   edm4hep::utils::anglePolar(rec_part.getMomentum()))
             << endmsg;
       }
     }
@@ -245,7 +245,7 @@ private:
       }
       // only 6-->20 mrad
       const auto mom_ion = removeCrossingAngle(part.getMomentum()); // rotateLabToIonDirection(part.getMomentum());
-      const auto mom_ion_theta = edm4eic::anglePolar(mom_ion);
+      const auto mom_ion_theta = edm4hep::utils::anglePolar(mom_ion);
       if (mom_ion_theta < m_thetaMinB0 || mom_ion_theta > m_thetaMaxB0) {
         continue;
       }
@@ -259,14 +259,14 @@ private:
       rc.emplace_back(rc_part, assoc);
       if (msgLevel(MSG::DEBUG)) {
         const auto& part_p      = part.getMomentum();
-        const auto part_p_pt    = edm4eic::magnitudeTransverse(part_p);
-        const auto part_p_mag   = edm4eic::magnitude(part_p);
-        const auto part_p_theta = edm4eic::anglePolar(part_p);
+        const auto part_p_pt    = edm4hep::utils::magnitudeTransverse(part_p);
+        const auto part_p_mag   = edm4hep::utils::magnitude(part_p);
+        const auto part_p_theta = edm4hep::utils::anglePolar(part_p);
         debug() << fmt::format("Found B0 particle: {}, ptrue: {}, pmeas: {}, pttrue: {}, ptmeas: {}, theta_true: {}, "
                                "theta_meas: {}",
-                               part.getPDG(), part_p_mag, edm4eic::magnitude(rc_part.momentum()), part_p_pt,
-                               edm4eic::magnitudeTransverse(rc_part.momentum()), part_p_theta,
-                               edm4eic::anglePolar(rc_part.momentum()))
+                               part.getPDG(), part_p_mag, edm4hep::utils::magnitude(rc_part.momentum()), part_p_pt,
+                               edm4hep::utils::magnitudeTransverse(rc_part.momentum()), part_p_theta,
+                               edm4hep::utils::anglePolar(rc_part.momentum()))
                 << endmsg;
       }
     }
@@ -288,7 +288,7 @@ private:
         continue;
       }
       const auto mom_ion = removeCrossingAngle(part.getMomentum()); // rotateLabToIonDirection(part.getMomentum());
-      const auto mom_ion_theta = edm4eic::anglePolar(mom_ion);
+      const auto mom_ion_theta = edm4hep::utils::anglePolar(mom_ion);
       if (mom_ion_theta < m_thetaMinRP || mom_ion_theta > m_thetaMaxRP ||
           mom_ion.z < m_pMinRigidityRP * ionBeamEnergy) {
         continue;
@@ -298,14 +298,14 @@ private:
       rc.emplace_back(rc_part, assoc);
       if (msgLevel(MSG::DEBUG)) {
         const auto& part_p      = part.getMomentum();
-        const auto part_p_pt    = edm4eic::magnitudeTransverse(part_p);
-        const auto part_p_mag   = edm4eic::magnitude(part_p);
-        const auto part_p_theta = edm4eic::anglePolar(part_p);
+        const auto part_p_pt    = edm4hep::utils::magnitudeTransverse(part_p);
+        const auto part_p_mag   = edm4hep::utils::magnitude(part_p);
+        const auto part_p_theta = edm4hep::utils::anglePolar(part_p);
         debug() << fmt::format("Found RP particle: {}, ptrue: {}, pmeas: {}, pttrue: {}, ptmeas: {}, theta_true: {}, "
                                "theta_meas: {}",
-                               part.getPDG(), part_p_mag, edm4eic::magnitude(rc_part.momentum()), part_p_pt,
-                               edm4eic::magnitudeTransverse(rc_part.momentum()), part_p_theta,
-                               edm4eic::anglePolar(rc_part.momentum()))
+                               part.getPDG(), part_p_mag, edm4hep::utils::magnitude(rc_part.momentum()), part_p_pt,
+                               edm4hep::utils::magnitudeTransverse(rc_part.momentum()), part_p_theta,
+                               edm4hep::utils::anglePolar(rc_part.momentum()))
                 << endmsg;
       }
     }
@@ -334,14 +334,14 @@ private:
       rc.emplace_back(rc_part, assoc);
       if (msgLevel(MSG::DEBUG)) {
         const auto& part_p      = part.getMomentum();
-        const auto part_p_pt    = edm4eic::magnitudeTransverse(part_p);
-        const auto part_p_mag   = edm4eic::magnitude(part_p);
-        const auto part_p_theta = edm4eic::anglePolar(part_p);
+        const auto part_p_pt    = edm4hep::utils::magnitudeTransverse(part_p);
+        const auto part_p_mag   = edm4hep::utils::magnitude(part_p);
+        const auto part_p_theta = edm4hep::utils::anglePolar(part_p);
         debug() << fmt::format("Found OMD particle: {}, ptrue: {}, pmeas: {}, pttrue: {}, ptmeas: {}, theta_true: {}, "
                                "theta_meas: {}",
-                               part.getPDG(), part_p_mag, edm4eic::magnitude(rc_part.momentum()), part_p_pt,
-                               edm4eic::magnitudeTransverse(rc_part.momentum()), part_p_theta,
-                               edm4eic::anglePolar(rc_part.momentum()))
+                               part.getPDG(), part_p_mag, edm4hep::utils::magnitude(rc_part.momentum()), part_p_pt,
+                               edm4hep::utils::magnitudeTransverse(rc_part.momentum()), part_p_theta,
+                               edm4hep::utils::anglePolar(rc_part.momentum()))
                 << endmsg;
       }
     }

--- a/truth/include/algorithms/truth/todo/TruthEnergyPositionClusterMerger.h
+++ b/truth/include/algorithms/truth/todo/TruthEnergyPositionClusterMerger.h
@@ -18,7 +18,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 using namespace Gaudi::Units;
 
@@ -167,7 +167,7 @@ public:
       new_clus.setTime(eclus.getTime());
       new_clus.setNhits(eclus.getNhits());
       // use nominal radius of 110cm, and use start vertex theta and phi
-      new_clus.setPosition(edm4eic::sphericalToVector(110.*cm, theta, phi));
+      new_clus.setPosition(edm4hep::utils::sphericalToVector(110.*cm, theta, phi));
       new_clus.addToClusters(eclus);
       if (msgLevel(MSG::DEBUG)) {
         debug() << " --> Processing energy cluster " << eclus.id() << ", mcID: " << mcID << ", energy: " << eclus.getEnergy()

--- a/truth/src/MC2SmearedParticle.cpp
+++ b/truth/src/MC2SmearedParticle.cpp
@@ -4,7 +4,7 @@
 #include <algorithms/truth/MC2SmearedParticle.h>
 
 #include <cmath>
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 namespace algorithms::truth {
 

--- a/truth/src/ParticlesWithTruthPID.cpp
+++ b/truth/src/ParticlesWithTruthPID.cpp
@@ -7,7 +7,7 @@
 #include <cmath>
 #include <fmt/format.h>
 
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 namespace algorithms::truth {
 
@@ -28,7 +28,7 @@ void ParticlesWithTruthPID::process(const ParticlesWithTruthPID::Input& input,
   std::vector<bool> consumed(mc.size(), false);
   for (const auto& trk : tracks) {
     const auto mom =
-        edm4eic::sphericalToVector(1.0 / std::abs(trk.getQOverP()), trk.getTheta(), trk.getPhi());
+        edm4hep::utils::sphericalToVector(1.0 / std::abs(trk.getQOverP()), trk.getTheta(), trk.getPhi());
     const auto charge_rec = trk.getCharge();
     // utility variables for matching
     int best_match    = -1;
@@ -46,11 +46,11 @@ void ParticlesWithTruthPID::process(const ParticlesWithTruthPID::Input& input,
       const auto p_mag    = std::hypot(p.x, p.y, p.z);
       const auto p_phi    = std::atan2(p.y, p.x);
       const auto p_eta    = std::atanh(p.z / p_mag);
-      const double dp_rel = std::abs((edm4eic::magnitude(mom) - p_mag) / p_mag);
+      const double dp_rel = std::abs((edm4hep::utils::magnitude(mom) - p_mag) / p_mag);
       // check the tolerance for sin(dphi/2) to avoid the hemisphere problem and allow
       // for phi rollovers
-      const double dsphi = std::abs(sin(0.5 * (edm4eic::angleAzimuthal(mom) - p_phi)));
-      const double deta  = std::abs((edm4eic::eta(mom) - p_eta));
+      const double dsphi = std::abs(sin(0.5 * (edm4hep::utils::angleAzimuthal(mom) - p_phi)));
+      const double deta  = std::abs((edm4hep::utils::eta(mom) - p_eta));
 
       if (dp_rel < m_pRelativeTolerance && deta < m_etaTolerance && dsphi < sinPhiOver2Tolerance) {
         const double delta = std::hypot(dp_rel / m_pRelativeTolerance, deta / m_etaTolerance,
@@ -78,7 +78,7 @@ void ParticlesWithTruthPID::process(const ParticlesWithTruthPID::Input& input,
       mass = mcpart.getMass();
     }
     rec_part.setType(static_cast<int16_t>(best_match >= 0 ? 0 : -1)); // @TODO: determine type codes
-    rec_part.setEnergy(std::hypot(edm4eic::magnitude(mom), mass));
+    rec_part.setEnergy(std::hypot(edm4hep::utils::magnitude(mom), mass));
     rec_part.setMomentum(mom);
     rec_part.setReferencePoint(referencePoint);
     rec_part.setCharge(charge_rec);
@@ -100,13 +100,13 @@ void ParticlesWithTruthPID::process(const ParticlesWithTruthPID::Input& input,
         const auto& mcpart = mc[best_match];
         debug() << fmt::format("Matched track with MC particle {}\n", best_match) << endmsg;
         debug() << fmt::format("  - Track: (mom: {}, theta: {}, phi: {}, charge: {})",
-                               edm4eic::magnitude(mom), edm4eic::anglePolar(mom),
-                               edm4eic::angleAzimuthal(mom), charge_rec)
+                               edm4hep::utils::magnitude(mom), edm4hep::utils::anglePolar(mom),
+                               edm4hep::utils::angleAzimuthal(mom), charge_rec)
                 << endmsg;
         const auto& p      = mcpart.getMomentum();
-        const auto p_mag   = edm4eic::magnitude(p);
-        const auto p_phi   = edm4eic::angleAzimuthal(p);
-        const auto p_theta = edm4eic::anglePolar(p);
+        const auto p_mag   = edm4hep::utils::magnitude(p);
+        const auto p_phi   = edm4hep::utils::angleAzimuthal(p);
+        const auto p_theta = edm4hep::utils::anglePolar(p);
         debug() << fmt::format(
                        "  - MC particle: (mom: {}, theta: {}, phi: {}, charge: {}, type: {}", p_mag,
                        p_theta, p_phi, mcpart.getCharge(), mcpart.getPDG())
@@ -114,8 +114,8 @@ void ParticlesWithTruthPID::process(const ParticlesWithTruthPID::Input& input,
       } else {
         debug() << fmt::format("Did not find a good match for track \n") << endmsg;
         debug() << fmt::format("  - Track: (mom: {}, theta: {}, phi: {}, charge: {})",
-                               edm4eic::magnitude(mom), edm4eic::anglePolar(mom),
-                               edm4eic::angleAzimuthal(mom), charge_rec)
+                               edm4hep::utils::magnitude(mom), edm4hep::utils::anglePolar(mom),
+                               edm4hep::utils::angleAzimuthal(mom), charge_rec)
                 << endmsg;
       }
     }

--- a/truth/src/todo/ClusterMerger.cpp
+++ b/truth/src/todo/ClusterMerger.cpp
@@ -17,7 +17,7 @@
 // Event Model related classes
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 using namespace Gaudi::Units;
 

--- a/truth/src/todo/InclusiveKinematicsTruth.cpp
+++ b/truth/src/todo/InclusiveKinematicsTruth.cpp
@@ -22,7 +22,7 @@ using ROOT::Math::PxPyPzEVector;
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/InclusiveKinematicsCollection.h"
 
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace Jug::Fast {
 
@@ -89,7 +89,7 @@ public:
       return StatusCode::SUCCESS;
     }
     const auto ei_p = ei_coll[0].getMomentum();
-    const auto ei_p_mag = edm4eic::magnitude(ei_p);
+    const auto ei_p_mag = edm4hep::utils::magnitude(ei_p);
     const auto ei_mass = m_electron;
     const PxPyPzEVector ei(ei_p.x, ei_p.y, ei_p.z, std::hypot(ei_p_mag, ei_mass));
 
@@ -102,7 +102,7 @@ public:
       return StatusCode::SUCCESS;
     }
     const auto pi_p = pi_coll[0].getMomentum();
-    const auto pi_p_mag = edm4eic::magnitude(pi_p);
+    const auto pi_p_mag = edm4hep::utils::magnitude(pi_p);
     const auto pi_mass = pi_coll[0].getPDG() == 2212 ? m_proton : m_neutron;
     const PxPyPzEVector pi(pi_p.x, pi_p.y, pi_p.z, std::hypot(pi_p_mag, pi_mass));
 
@@ -119,7 +119,7 @@ public:
       return StatusCode::SUCCESS;
     }
     const auto ef_p = ef_coll[0].getMomentum();
-    const auto ef_p_mag = edm4eic::magnitude(ef_p);
+    const auto ef_p_mag = edm4hep::utils::magnitude(ef_p);
     const auto ef_mass = m_electron;
     const PxPyPzEVector ef(ef_p.x, ef_p.y, ef_p.z, std::hypot(ef_p_mag, ef_mass));
 

--- a/truth/src/todo/MatchClusters.cpp
+++ b/truth/src/todo/MatchClusters.cpp
@@ -25,7 +25,7 @@
 #include "edm4eic/MCRecoParticleAssociationCollection.h"
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/TrackParametersCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace Jug::Fast {
 
@@ -271,7 +271,7 @@ private:
     const float energy = clus.getEnergy();
     const float p = energy < mass ? 0 : std::sqrt(energy * energy - mass * mass);
     const auto position = clus.getPosition();
-    const auto momentum = p * (position / edm4eic::magnitude(position));
+    const auto momentum = p * (position / edm4hep::utils::magnitude(position));
     // setup our particle
     edm4eic::MutableReconstructedParticle part;
     part.setMomentum(momentum);

--- a/truth/src/todo/SmearedFarForwardParticles.cpp
+++ b/truth/src/todo/SmearedFarForwardParticles.cpp
@@ -17,7 +17,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/MCRecoParticleAssociationCollection.h"
 #include "edm4eic/ReconstructedParticleCollection.h"
-#include "edm4eic/vector_utils.h"
+#include "edm4hep/utils/vector_utils.h"
 
 namespace {
 enum DetectorTags { kTagB0 = 1, kTagRP = 2, kTagOMD = 3, kTagZDC = 4 };
@@ -160,8 +160,8 @@ private:
         continue;
       }
       // only 0-->4.5 mrad
-      const double mom_ion_theta = edm4eic::anglePolar(mom_ion);
-      const double mom_ion_phi   = edm4eic::angleAzimuthal(mom_ion);
+      const double mom_ion_theta = edm4hep::utils::anglePolar(mom_ion);
+      const double mom_ion_phi   = edm4hep::utils::angleAzimuthal(mom_ion);
       if (mom_ion_theta > 4.5 / 1000.) {
         continue;
       }
@@ -192,7 +192,7 @@ private:
       const double phis = phi + dphi;
       const double moms = sqrt(Es * Es - part.getMass() * part.getMass());
       // now cast back into float
-      const auto mom3s_ion = edm4eic::sphericalToVector(moms, ths, phis);
+      const auto mom3s_ion = edm4hep::utils::sphericalToVector(moms, ths, phis);
       const auto mom3s     = rotateIonToLabDirection(mom3s_ion);
       RecPart rec_part;
       rec_part.setType(kTagZDC);
@@ -220,8 +220,8 @@ private:
         debug()
             << fmt::format(
                    "Found ZDC particle: {}, Etrue: {}, Emeas: {}, ptrue: {}, pmeas: {}, theta_true: {}, theta_meas: {}",
-                   part.getPDG(), E, rec_part.getEnergy(), part_p_mag, edm4eic::magnitude(rec_part.getMomentum()), th,
-                   edm4eic::anglePolar(rec_part.getMomentum()))
+                   part.getPDG(), E, rec_part.getEnergy(), part_p_mag, edm4hep::utils::magnitude(rec_part.getMomentum()), th,
+                   edm4hep::utils::anglePolar(rec_part.getMomentum()))
             << endmsg;
       }
     }
@@ -245,7 +245,7 @@ private:
       }
       // only 6-->20 mrad
       const auto mom_ion = removeCrossingAngle(part.getMomentum()); // rotateLabToIonDirection(part.getMomentum());
-      const auto mom_ion_theta = edm4eic::anglePolar(mom_ion);
+      const auto mom_ion_theta = edm4hep::utils::anglePolar(mom_ion);
       if (mom_ion_theta < m_thetaMinB0 || mom_ion_theta > m_thetaMaxB0) {
         continue;
       }
@@ -259,14 +259,14 @@ private:
       rc.emplace_back(rc_part, assoc);
       if (msgLevel(MSG::DEBUG)) {
         const auto& part_p      = part.getMomentum();
-        const auto part_p_pt    = edm4eic::magnitudeTransverse(part_p);
-        const auto part_p_mag   = edm4eic::magnitude(part_p);
-        const auto part_p_theta = edm4eic::anglePolar(part_p);
+        const auto part_p_pt    = edm4hep::utils::magnitudeTransverse(part_p);
+        const auto part_p_mag   = edm4hep::utils::magnitude(part_p);
+        const auto part_p_theta = edm4hep::utils::anglePolar(part_p);
         debug() << fmt::format("Found B0 particle: {}, ptrue: {}, pmeas: {}, pttrue: {}, ptmeas: {}, theta_true: {}, "
                                "theta_meas: {}",
-                               part.getPDG(), part_p_mag, edm4eic::magnitude(rc_part.momentum()), part_p_pt,
-                               edm4eic::magnitudeTransverse(rc_part.momentum()), part_p_theta,
-                               edm4eic::anglePolar(rc_part.momentum()))
+                               part.getPDG(), part_p_mag, edm4hep::utils::magnitude(rc_part.momentum()), part_p_pt,
+                               edm4hep::utils::magnitudeTransverse(rc_part.momentum()), part_p_theta,
+                               edm4hep::utils::anglePolar(rc_part.momentum()))
                 << endmsg;
       }
     }
@@ -288,7 +288,7 @@ private:
         continue;
       }
       const auto mom_ion = removeCrossingAngle(part.getMomentum()); // rotateLabToIonDirection(part.getMomentum());
-      const auto mom_ion_theta = edm4eic::anglePolar(mom_ion);
+      const auto mom_ion_theta = edm4hep::utils::anglePolar(mom_ion);
       if (mom_ion_theta < m_thetaMinRP || mom_ion_theta > m_thetaMaxRP ||
           mom_ion.z < m_pMinRigidityRP * ionBeamEnergy) {
         continue;
@@ -298,14 +298,14 @@ private:
       rc.emplace_back(rc_part, assoc);
       if (msgLevel(MSG::DEBUG)) {
         const auto& part_p      = part.getMomentum();
-        const auto part_p_pt    = edm4eic::magnitudeTransverse(part_p);
-        const auto part_p_mag   = edm4eic::magnitude(part_p);
-        const auto part_p_theta = edm4eic::anglePolar(part_p);
+        const auto part_p_pt    = edm4hep::utils::magnitudeTransverse(part_p);
+        const auto part_p_mag   = edm4hep::utils::magnitude(part_p);
+        const auto part_p_theta = edm4hep::utils::anglePolar(part_p);
         debug() << fmt::format("Found RP particle: {}, ptrue: {}, pmeas: {}, pttrue: {}, ptmeas: {}, theta_true: {}, "
                                "theta_meas: {}",
-                               part.getPDG(), part_p_mag, edm4eic::magnitude(rc_part.momentum()), part_p_pt,
-                               edm4eic::magnitudeTransverse(rc_part.momentum()), part_p_theta,
-                               edm4eic::anglePolar(rc_part.momentum()))
+                               part.getPDG(), part_p_mag, edm4hep::utils::magnitude(rc_part.momentum()), part_p_pt,
+                               edm4hep::utils::magnitudeTransverse(rc_part.momentum()), part_p_theta,
+                               edm4hep::utils::anglePolar(rc_part.momentum()))
                 << endmsg;
       }
     }
@@ -334,14 +334,14 @@ private:
       rc.emplace_back(rc_part, assoc);
       if (msgLevel(MSG::DEBUG)) {
         const auto& part_p      = part.getMomentum();
-        const auto part_p_pt    = edm4eic::magnitudeTransverse(part_p);
-        const auto part_p_mag   = edm4eic::magnitude(part_p);
-        const auto part_p_theta = edm4eic::anglePolar(part_p);
+        const auto part_p_pt    = edm4hep::utils::magnitudeTransverse(part_p);
+        const auto part_p_mag   = edm4hep::utils::magnitude(part_p);
+        const auto part_p_theta = edm4hep::utils::anglePolar(part_p);
         debug() << fmt::format("Found OMD particle: {}, ptrue: {}, pmeas: {}, pttrue: {}, ptmeas: {}, theta_true: {}, "
                                "theta_meas: {}",
-                               part.getPDG(), part_p_mag, edm4eic::magnitude(rc_part.momentum()), part_p_pt,
-                               edm4eic::magnitudeTransverse(rc_part.momentum()), part_p_theta,
-                               edm4eic::anglePolar(rc_part.momentum()))
+                               part.getPDG(), part_p_mag, edm4hep::utils::magnitude(rc_part.momentum()), part_p_pt,
+                               edm4hep::utils::magnitudeTransverse(rc_part.momentum()), part_p_theta,
+                               edm4hep::utils::anglePolar(rc_part.momentum()))
                 << endmsg;
       }
     }

--- a/truth/src/todo/TruthEnergyPositionClusterMerger.cpp
+++ b/truth/src/todo/TruthEnergyPositionClusterMerger.cpp
@@ -18,7 +18,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4eic/ClusterCollection.h"
 #include "edm4eic/MCRecoClusterParticleAssociationCollection.h"
-#include <edm4eic/vector_utils.h>
+#include <edm4hep/utils/vector_utils.h>
 
 using namespace Gaudi::Units;
 
@@ -167,7 +167,7 @@ public:
       new_clus.setTime(eclus.getTime());
       new_clus.setNhits(eclus.getNhits());
       // use nominal radius of 110cm, and use start vertex theta and phi
-      new_clus.setPosition(edm4eic::sphericalToVector(110.*cm, theta, phi));
+      new_clus.setPosition(edm4hep::utils::sphericalToVector(110.*cm, theta, phi));
       new_clus.addToClusters(eclus);
       if (msgLevel(MSG::DEBUG)) {
         debug() << " --> Processing energy cluster " << eclus.id() << ", mcID: " << mcID << ", energy: " << eclus.getEnergy()


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The version of edm4eic that we are currently using has a problem when using non-legacy mode in c++20. This has since been fixed (https://github.com/eic/EDM4eic/pull/57), but it is likely better to use the upstream EDM4hep vector utils since externalizes some support responsibilities. We've already done the same in EICrecon and juggler, and I'm looking forward to the day when I don't have to make every fix in three places.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.