### PR TITLE
fix: avoid copy in structured binding in dummy.cpp testLogger

### DIFF
--- a/core/src/dummy.cpp
+++ b/core/src/dummy.cpp
@@ -28,7 +28,7 @@ public:
 
     std::cout << std::endl;
     info() << "Checking the existing services:" << endmsg;
-    for (const auto [key, value] : ServiceSvc::instance().services()) {
+    for (const auto& [key, value] : ServiceSvc::instance().services()) {
       info() << " - " << key << endmsg;
     }
   }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Addresses C++20 warning/error. 
```
make[2]: Entering directory '/home/wdconinc/git/algorithms/build'
[ 11%] Building CXX object core/CMakeFiles/algocore.dir/src/dummy.cpp.o
[ 22%] Building CXX object core/CMakeFiles/algocore.dir/src/geo.cpp.o
[ 33%] Building CXX object core/CMakeFiles/algocore.dir/src/random.cpp.o
/home/wdconinc/git/algorithms/core/src/dummy.cpp: In constructor ‘testLogger::testLogger()’:
/home/wdconinc/git/algorithms/core/src/dummy.cpp:31:21: error: loop variable ‘<structured bindings>’ creates a copy from type ‘const std::pair<const std::basic_string_view<char>, algorithms::ServiceBase*>’ [-Werror=range-loop-construct]
   31 |     for (const auto [key, value] : ServiceSvc::instance().services()) {
      |                     ^~~~~~~~~~~~
/home/wdconinc/git/algorithms/core/src/dummy.cpp:31:21: note: use reference type to prevent copying
   31 |     for (const auto [key, value] : ServiceSvc::instance().services()) {
      |                     ^~~~~~~~~~~~
      |                     &
cc1plus: all warnings being treated as errors
make[2]: *** [core/CMakeFiles/algocore.dir/build.make:76: core/CMakeFiles/algocore.dir/src/dummy.cpp.o] Error 1
make[2]: Leaving directory '/home/wdconinc/git/algorithms/build'
make[1]: *** [CMakeFiles/Makefile2:134: core/CMakeFiles/algocore.dir/all] Error 2
```