### PR TITLE
fix: switch to GeoSvc::init(const dd4hep::Detector*)

### DIFF
--- a/core/include/algorithms/geo.h
+++ b/core/include/algorithms/geo.h
@@ -23,7 +23,7 @@ public:
   // Initialize the geometry service, to be called after with a global detector
   // pointer (will not re-initialize), or after at least the detectors property was specified
   // (will load XML and then fully initialize)
-  void init(dd4hep::Detector* = nullptr);
+  void init(const dd4hep::Detector* = nullptr);
 
   // TODO check const-ness
   gsl::not_null<const dd4hep::Detector*> detector() const { return m_detector; }
@@ -33,7 +33,8 @@ public:
   }
 
 private:
-  dd4hep::Detector* m_detector = nullptr;
+  const dd4hep::Detector* m_detector = nullptr;
+  std::unique_ptr<const dd4hep::Detector> m_detector_ptr;
   std::unique_ptr<const dd4hep::rec::CellIDPositionConverter> m_converter;
 
   // Configuration variables. These only need to be specified if we are actually running

--- a/core/src/geo.cpp
+++ b/core/src/geo.cpp
@@ -7,23 +7,25 @@
 
 namespace algorithms {
 
-void GeoSvc::init(dd4hep::Detector* det) {
+void GeoSvc::init(const dd4hep::Detector* det) {
   if (det) {
     info() << "Initializing geometry service from pre-initialized detector" << endmsg;
     m_detector = det;
     // no detector given, need to self-initialize
   } else {
     info() << "No external detector provided, self-initializing" << endmsg;
-    m_detector = &(dd4hep::Detector::getInstance());
+    auto detector = dd4hep::Detector::make_unique("");
     if (m_xml_list.empty()) {
       // TODO handle error
     }
     for (std::string_view name : m_xml_list) {
       info() << fmt::format("Loading compact file: {}", "name") << endmsg;
-      m_detector->fromCompact(std::string(name));
+      detector->fromCompact(std::string(name));
     }
-    m_detector->volumeManager();
-    m_detector->apply("DD4hepVolumeManager", 0, nullptr);
+    detector->volumeManager();
+    detector->apply("DD4hepVolumeManager", 0, nullptr);
+    m_detector_ptr = std::move(detector);
+    m_detector = m_detector_ptr.get();
   }
   // always: instantiate cellIDConverter
   m_converter = std::make_unique<const dd4hep::rec::CellIDPositionConverter>(*m_detector);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This implements GeoSvc::init(const dd4hep::Detector*), which requires storing the xml geometry in a unique_ptr, creating it non-const, moving it, and handing out const get()'s to it.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #11)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.