### PR TITLE
feat: add logger interfaces that forward to fmt::format

### DIFF
--- a/core/include/algorithms/logger.h
+++ b/core/include/algorithms/logger.h
@@ -191,6 +191,25 @@ protected:
   void debug(std::string_view msg) const { report<LogLevel::kDebug>(msg); }
   void trace(std::string_view msg) const { report<LogLevel::kTrace>(msg); }
 
+  template <typename ...T> constexpr void critical(fmt::format_string<T...> fmt, T&&... args) const {
+    report_fmt<LogLevel::kCritical>(fmt, std::forward<decltype(args)>(args)...);
+  }
+  template <typename ...T> constexpr void error(fmt::format_string<T...> fmt, T&&... args) const {
+    report_fmt<LogLevel::kError>(fmt, std::forward<decltype(args)>(args)...);
+  }
+  template <typename ...T> constexpr void warning(fmt::format_string<T...> fmt, T&&... args) const {
+    report_fmt<LogLevel::kWarning>(fmt, std::forward<decltype(args)>(args)...);
+  }
+  template <typename ...T> constexpr void info(fmt::format_string<T...> fmt, T&&... args) const {
+    report_fmt<LogLevel::kInfo>(fmt, std::forward<decltype(args)>(args)...);
+  }
+  template <typename ...T> constexpr void debug(fmt::format_string<T...> fmt, T&&... args) const {
+    report_fmt<LogLevel::kDebug>(fmt, std::forward<decltype(args)>(args)...);
+  }
+  template <typename ...T> constexpr void trace(fmt::format_string<T...> fmt, T&&... args) const {
+    report_fmt<LogLevel::kTrace>(fmt, std::forward<decltype(args)>(args)...);
+  }
+
   bool aboveCriticalThreshold() const { return m_level >= LogLevel::kCritical; }
   bool aboveErrorThreshold() const { return m_level >= LogLevel::kError; }
   bool aboveWarningThreshold() const { return m_level >= LogLevel::kWarning; }
@@ -213,6 +232,13 @@ protected:
   }
 
 private:
+  template <LogLevel l, typename ...T>
+  constexpr void report_fmt(fmt::format_string<T...> fmt, T&&... args) const {
+    if (l >= m_level) {
+      m_logger.report(l, m_caller, fmt::format(fmt, std::forward<decltype(args)>(args)...));
+    }
+  }
+
   template <LogLevel l> void report(std::string_view msg) const {
     if (l >= m_level) {
       m_logger.report(l, m_caller, msg);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This allows `error("{}", x)` instead of `error(fmt::format("{}", x))`. Care was taken to maintain the compile-time checking of the format string that fmt::format provides.

I kept the `string_view` interfaces as well, since they are a shorter code path and probably preferred for the const-char strings.

Likely depends on #13 due to context, but is independent in functionality.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.