### PR TITLE
fix: find_dependency fmt in algorithmsConfig.cmake

### DIFF
--- a/cmake/algorithmsConfig.cmake.in
+++ b/cmake/algorithmsConfig.cmake.in
@@ -25,7 +25,7 @@ foreach(_component ${algorithms_FIND_COMPONENTS})
     else()
       # not supported and optional -> skip
       list(REMOVE_ITEM algorithms_FIND_COMPONENTS ${_component})
-      if(NOT Acts_FIND_QUIETLY)
+      if(NOT algorithms_FIND_QUIETLY)
         message(STATUS "optional component '${_component}' not found")
       endif()
     endif()
@@ -33,13 +33,14 @@ foreach(_component ${algorithms_FIND_COMPONENTS})
 endforeach()
 
 # find external dependencies that are needed to link with algorithms. since the
-# exported Acts targets only store the linked external target names they need
+# exported algorithms targets only store the linked external target names they need
 # to be found again. this avoids hard-coded paths and makes the installed
 # config/library relocatable. use exact version match where possible to ensure
 # the same versions are found that were used at build time.
 # `find_dependency` is a wrapper around `find_package` that automatically
 # handles QUIET and REQUIRED parameters.
 include(CMakeFindDependencyMacro)
+find_dependency(fmt @fmt_VERSION@ CONFIG EXACT)
 if(Acts IN_LIST algorithms_COMPONENTS)
   find_dependency(Acts @Acts_VERSION@ CONFIG EXACT)
 endif()


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This ensures that find_package(fmt) is run when external projects that depend on algorithms, since fmt is a dependency of algorithms, including in core.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.