### PR TITLE
fix: add default parameters to random distributions (requires C++20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ include(algorithmsRetrieveVersion)
 
 project(algorithms VERSION ${_algorithms_version} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 20)
+    message(STATUS "${PROJECT_NAME}: Setting default C++ standard to ${CMAKE_CXX_STANDARD}")
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/core/include/algorithms/random.h
+++ b/core/include/algorithms/random.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <mutex>
@@ -26,27 +27,27 @@ class Generator {
 public:
   Generator(const RandomEngineCB& gen, const size_t cache_size) : m_gen{gen, cache_size} {}
 
-  template <class Int = int> Int uniform_int(const Int min, const Int max) const {
+  template <std::integral Int = int> Int uniform_int(const Int min = 0, const Int max = 1) const {
     std::uniform_int_distribution<Int> d{min, max};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <class Float = double> Float uniform_double(const Float min, const Float max) const {
+  template <std::floating_point Float = double> Float uniform_double(const Float min = 0, const Float max = 1) const {
     std::uniform_real_distribution<Float> d{min, max};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <class Int = int> Int poisson(const Int mean) const {
+  template <std::integral Int = int> Int poisson(const Int mean = 1) const {
     std::poisson_distribution<Int> d{mean};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <class Float = double> Float exponential(const Float lambda) const {
+  template <std::floating_point Float = double> Float exponential(const Float lambda = 1) const {
     std::exponential_distribution<Float> d{lambda};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <class Float = double> Float gaussian(const Float mu, const Float sigma) const {
+  template <std::floating_point Float = double> Float gaussian(const Float mu = 0, const Float sigma = 1) const {
     std::normal_distribution<Float> d{mu, sigma};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);

--- a/core/include/algorithms/random.h
+++ b/core/include/algorithms/random.h
@@ -28,27 +28,27 @@ class Generator {
 public:
   Generator(const RandomEngineCB& gen, const size_t cache_size) : m_gen{gen, cache_size} {}
 
-  template <std::integral Int = int> Int uniform_int(const Int min = 0, const Int max = 1) const {
+  template <std::integral Int = int> Int uniform_int(const Int min = Int{0}, const Int max = Int{1}) const {
     std::uniform_int_distribution<Int> d{min, max};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <std::floating_point Float = double> Float uniform_double(const Float min = 0, const Float max = 1) const {
+  template <std::floating_point Float = double> Float uniform_double(const Float min = Float{0}, const Float max = Float{1}) const {
     std::uniform_real_distribution<Float> d{min, max};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <std::integral Int = int> Int poisson(const Int mean = 1) const {
+  template <std::integral Int = int> Int poisson(const Int mean = Int{1}) const {
     std::poisson_distribution<Int> d{mean};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <std::floating_point Float = double> Float exponential(const Float lambda = 1) const {
+  template <std::floating_point Float = double> Float exponential(const Float lambda = Float{1}) const {
     std::exponential_distribution<Float> d{lambda};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);
   }
-  template <std::floating_point Float = double> Float gaussian(const Float mu = 0, const Float sigma = 1) const {
+  template <std::floating_point Float = double> Float gaussian(const Float mu = Float{0}, const Float sigma = Float{1}) const {
     std::normal_distribution<Float> d{mu, sigma};
     std::lock_guard<std::mutex> lock{m_mutex};
     return d(m_gen);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This adds constraints for integral and floating point types to make sure that default parameter values are well-defined. Instead of `gaussian(0.,1.)`, we can now also use `gaussian()` with the same effect. This reduces the need to specify constants where they can be easily swapped, e.g. mu and sigma.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.