### PR TITLE
fix: use qOverP to get the charge of TrackParameters

### DIFF
--- a/truth/src/ParticlesWithTruthPID.cpp
+++ b/truth/src/ParticlesWithTruthPID.cpp
@@ -29,7 +29,7 @@ void ParticlesWithTruthPID::process(const ParticlesWithTruthPID::Input& input,
   for (const auto& trk : tracks) {
     const auto mom =
         edm4hep::utils::sphericalToVector(1.0 / std::abs(trk.getQOverP()), trk.getTheta(), trk.getPhi());
-    const auto charge_rec = trk.getCharge();
+    const auto charge_rec = std::copysign(1., trk.getQOverP());
     // utility variables for matching
     int best_match    = -1;
     double best_delta = std::numeric_limits<double>::max();


### PR DESCRIPTION
### Briefly, what does this PR introduce?
After https://github.com/eic/EDM4eic/pull/58, there is no more `charge` field in edm4eic::TrackParameters, so we have to get this from `qOverP`, but this is backwards compatible.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: algorithms fails to compile with edm4eic main after https://github.com/eic/EDM4eic/pull/58)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.