### PR TITLE
fix: algorithms uses C++ only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # determine project version; sets _algorithms_version
 include(algorithmsRetrieveVersion)
 
-project(algorithms VERSION ${_algorithms_version})
+project(algorithms VERSION ${_algorithms_version} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
 if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR tells CMake not to look for and test a C compiler, only a C++ compiler.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: algorithms seems to need a C compiler now)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
