### PR TITLE
feat: move protected report_fmt to public log function

### DIFF
--- a/core/include/algorithms/logger.h
+++ b/core/include/algorithms/logger.h
@@ -192,22 +192,22 @@ protected:
   void trace(std::string_view msg) const { report<LogLevel::kTrace>(msg); }
 
   template <typename ...T> constexpr void critical(fmt::format_string<T...> fmt, T&&... args) const {
-    report_fmt<LogLevel::kCritical>(fmt, std::forward<decltype(args)>(args)...);
+    log<LogLevel::kCritical>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void error(fmt::format_string<T...> fmt, T&&... args) const {
-    report_fmt<LogLevel::kError>(fmt, std::forward<decltype(args)>(args)...);
+    log<LogLevel::kError>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void warning(fmt::format_string<T...> fmt, T&&... args) const {
-    report_fmt<LogLevel::kWarning>(fmt, std::forward<decltype(args)>(args)...);
+    log<LogLevel::kWarning>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void info(fmt::format_string<T...> fmt, T&&... args) const {
-    report_fmt<LogLevel::kInfo>(fmt, std::forward<decltype(args)>(args)...);
+    log<LogLevel::kInfo>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void debug(fmt::format_string<T...> fmt, T&&... args) const {
-    report_fmt<LogLevel::kDebug>(fmt, std::forward<decltype(args)>(args)...);
+    log<LogLevel::kDebug>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void trace(fmt::format_string<T...> fmt, T&&... args) const {
-    report_fmt<LogLevel::kTrace>(fmt, std::forward<decltype(args)>(args)...);
+    log<LogLevel::kTrace>(fmt, std::forward<decltype(args)>(args)...);
   }
 
   bool aboveCriticalThreshold() const { return m_level >= LogLevel::kCritical; }
@@ -231,14 +231,14 @@ protected:
     return os;
   }
 
-private:
   template <LogLevel l, typename ...T>
-  constexpr void report_fmt(fmt::format_string<T...> fmt, T&&... args) const {
+  constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
     if (l >= m_level) {
       m_logger.report(l, m_caller, fmt::format(fmt, std::forward<decltype(args)>(args)...));
     }
   }
 
+private:
   template <LogLevel l> void report(std::string_view msg) const {
     if (l >= m_level) {
       m_logger.report(l, m_caller, msg);


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades the private `template<LogLevel l,...> report_fmt(fmt,args)` to protected `template<LogLevel l,...> log(fmt, args)`. This allows the following logging modalities in user code:
- `error() << msg << endmsg`
- `error(fmt, msg)`
- `log<LogLevel::kError>(fmt, msg)`

This allows for easier downstream user code that is templated on the log level.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. Unless maybe if you are inheriting LoggerMixin and have `log(fmt, msg)` already or something.

### Does this PR change default behavior?
No.