### PR TITLE
fix: log<lvl> -> report_fmt<lvl> to avoid unqualified name lookup issues

### DIFF
--- a/core/include/algorithms/logger.h
+++ b/core/include/algorithms/logger.h
@@ -192,22 +192,22 @@ protected:
   void trace(std::string_view msg) const { report<LogLevel::kTrace>(msg); }
 
   template <typename ...T> constexpr void critical(fmt::format_string<T...> fmt, T&&... args) const {
-    log<LogLevel::kCritical>(fmt, std::forward<decltype(args)>(args)...);
+    report_fmt<LogLevel::kCritical>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void error(fmt::format_string<T...> fmt, T&&... args) const {
-    log<LogLevel::kError>(fmt, std::forward<decltype(args)>(args)...);
+    report_fmt<LogLevel::kError>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void warning(fmt::format_string<T...> fmt, T&&... args) const {
-    log<LogLevel::kWarning>(fmt, std::forward<decltype(args)>(args)...);
+    report_fmt<LogLevel::kWarning>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void info(fmt::format_string<T...> fmt, T&&... args) const {
-    log<LogLevel::kInfo>(fmt, std::forward<decltype(args)>(args)...);
+    report_fmt<LogLevel::kInfo>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void debug(fmt::format_string<T...> fmt, T&&... args) const {
-    log<LogLevel::kDebug>(fmt, std::forward<decltype(args)>(args)...);
+    report_fmt<LogLevel::kDebug>(fmt, std::forward<decltype(args)>(args)...);
   }
   template <typename ...T> constexpr void trace(fmt::format_string<T...> fmt, T&&... args) const {
-    log<LogLevel::kTrace>(fmt, std::forward<decltype(args)>(args)...);
+    report_fmt<LogLevel::kTrace>(fmt, std::forward<decltype(args)>(args)...);
   }
 
   bool aboveCriticalThreshold() const { return m_level >= LogLevel::kCritical; }
@@ -232,7 +232,7 @@ protected:
   }
 
   template <LogLevel l, typename ...T>
-  constexpr void log(fmt::format_string<T...> fmt, T&&... args) const {
+  constexpr void report_fmt(fmt::format_string<T...> fmt, T&&... args) const {
     if (l >= m_level) {
       m_logger.report(l, m_caller, fmt::format(fmt, std::forward<decltype(args)>(args)...));
     }


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Avoid unqualified name lookup confusion with `log` where `std::log` is meant.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.