### PR TITLE
fix: allow EDM4hep v1.0.0 and later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,10 @@ endif()
 
 find_package(Microsoft.GSL CONFIG)
 find_package(EDM4EIC REQUIRED)
-find_package(EDM4HEP 0.4.1 REQUIRED)
+find_package(EDM4HEP REQUIRED)
+if(${EDM4HEP_VERSION} VERSION_LESS 0.4.1)
+  message(FATAL_ERROR "EDM4HEP version ${EDM4HEP_VERSION} is too old. Please use at least version 0.4.1.")
+endif()
 find_package(DD4hep COMPONENTS DDRec REQUIRED)
 find_package(fmt REQUIRED)
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the EDM4hep version check to allow v1.0.0 and later as well (since EDM4hep uses SameMajorVersion policy).